### PR TITLE
Update develop instructions to use ./build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ you may also want to generate a [checksum](https://www.npmjs.com/package/checksu
 # developing
 
         npm install
+        ./build "Board name"
         npm run generate-keys
         npm run dev
 


### PR DESCRIPTION
Just a simple fix for the dev instructions to avoid confusion.
