### PR TITLE
`dist` directory should be available after clone

### DIFF
--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+# ignore everything in this directory but this file
+!.gitignore


### PR DESCRIPTION
Created a `dist` directory and added a `.gitignore` file within so we don't get confusing "no such directory" error on first build.
